### PR TITLE
Refine Markdown Rendering for Consistency and Bug Fixes

### DIFF
--- a/components/MarkdownComponents.tsx
+++ b/components/MarkdownComponents.tsx
@@ -152,7 +152,7 @@ export const H2 = ({ children, className, ...rest }: HeadingProps) => (
 );
 
 export const H3 = ({ children, className, ...rest }: HeadingProps) => (
-  <h3 className={cn("text-lg font-semibold mt-2 mb-1", className)} {...rest}>{children}</h3>
+  <h3 className={cn("text-lg font-semibold mt-2 mb-1 border-b pb-1 border-[var(--border)]", className)} {...rest}>{children}</h3>
 );
 
 export const Strong = ({ children, className, ...rest }: StrongProps) => (
@@ -164,7 +164,7 @@ export const Em = ({ children, className, ...rest }: EmProps) => (
 );
 
 export const Table = ({ children, className, ...rest }: TableProps) => (
-  <div className="markdown-table-wrapper my-2">
+  <div className="markdown-table-wrapper my-2 overflow-x-auto">
     <table className={cn("w-full border-collapse border border-[var(--border)]", className)} {...rest}>{children}</table>
   </div>
 );

--- a/src/sidePanel/Message.tsx
+++ b/src/sidePanel/Message.tsx
@@ -49,8 +49,8 @@ const ThinkingBlock = ({ content }: { content: string }) => {
           >
             <div className="markdown-body">
               <Markdown
-                remarkPlugins={[remarkGfm]}
-                components={markdownComponents}
+                remarkPlugins={[[remarkGfm, { singleTilde: false }], remarkSupersub]}
+                components={messageMarkdownComponents}
               >
                 {content}
               </Markdown>
@@ -112,9 +112,9 @@ export const EditableMessage: FC<MessageProps> = ({
   return (
     <div
       className={cn(
-        "border rounded-2xl text-base font-semibold",
+        "border rounded-2xl text-base",
         "w-[calc(100%-2rem)] mx-1 my-2",
-        "pb-1 pl-4 pr-4 pt-1", 
+        "pb-1 pl-4 pr-4 pt-1",
         "shadow-lg text-left relative",
         turn.role === 'assistant' ? 'bg-accent border-[var(--text)]/20' : 'bg-primary/10 border-[var(--text)]/20',
         config?.paperTexture ? 'chat-message-bubble' : '',
@@ -166,7 +166,7 @@ export const EditableMessage: FC<MessageProps> = ({
         <div className="message-markdown markdown-body relative z-[1] text-foreground">
           {turn.role === 'assistant' && turn.webDisplayContent && (
             <div className="message-prefix">
-              <Markdown remarkPlugins={[[remarkGfm, { singleTilde: false }], remarkSupersub]} components={markdownComponents}>
+              <Markdown remarkPlugins={[[remarkGfm, { singleTilde: false }], remarkSupersub]} components={messageMarkdownComponents}>
                 {`~From the Internet~
 ${turn.webDisplayContent}
 

--- a/src/sidePanel/NoteSystemView.tsx
+++ b/src/sidePanel/NoteSystemView.tsx
@@ -325,7 +325,7 @@ export const NoteSystemView: React.FC<NoteSystemViewProps> = ({ triggerOpenCreat
                         Date: {new Date(note.lastUpdatedAt).toLocaleString()}
                       </p>
                       <div className="text-sm whitespace-pre-wrap break-words">
-                        <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                        <Markdown remarkPlugins={[remarkGfm]} components={noteSystemMarkdownComponents}>
                           {note.content}
                         </Markdown>
                       </div>


### PR DESCRIPTION
This commit addresses inconsistencies and a bug in markdown rendering across the notes system and chat messages.

Key changes:

- **Fix (NoteSystemView):** Corrected a bug where custom markdown components (specifically for `pre` blocks with themed backgrounds and copy buttons) were not being applied to note previews in `HoverCardContent`. Notes now correctly use `noteSystemMarkdownComponents`.

- **Feat (Message):** Standardized markdown rendering within chat messages:
    - `ThinkingBlock` and `webDisplayContent` now use `messageMarkdownComponents` and the same `remarkPlugins` (GFM with `singleTilde: false` for sub/super compatibility, and `remarkSupersub`) as the main message content. This ensures consistent styling of code blocks (copy button) and support for all markdown syntax across message parts.
    - Removed global `font-semibold` from message bubbles. Base text is now normal weight, improving readability and allowing standard markdown emphasis.

- **Style (MarkdownComponents):**
    - Added a bottom border to `H3` elements to align their styling with `H1` and `H2`.
    - Added `overflow-x-auto` to the `markdown-table-wrapper` to ensure wide tables are scrollable and do not break page layout.

These changes improve the visual consistency, fix a rendering bug, and enhance the overall user experience when interacting with markdown content.