### PR TITLE
Refactor: Break down useTools.ts into separate files

### DIFF
--- a/src/sidePanel/hooks/toolDefinitions.ts
+++ b/src/sidePanel/hooks/toolDefinitions.ts
@@ -1,0 +1,95 @@
+// src/sidePanel/hooks/toolDefinitions.ts
+
+interface ToolParameterProperty {
+  type: string;
+  description: string;
+  enum?: string[];
+  items?: { type: string };
+}
+
+export interface ToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: {
+      type: 'object';
+      properties: {
+        [key: string]: ToolParameterProperty;
+      };
+      required?: string[];
+    };
+  };
+}
+
+export const toolDefinitions: ToolDefinition[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'note.save', // Renamed from saveNote
+      description:
+        "Saves a new note to the user's persistent note system. Use this when the user wants to record information, decisions, or create a new structured note.",
+      parameters: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            description: 'The main content of the note. This is mandatory.',
+          },
+          title: {
+            type: 'string',
+            description:
+              'An optional title for the note. If not provided, a default title will be generated.',
+          },
+          tags: {
+            type: 'array',
+            description:
+              'An optional list of tags (strings) to categorize the note.',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        required: ['content'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'fetcher', // Name remains the same as per instructions
+      description:
+        'Fetches the main textual content of a given URL. Use this to get the content of a webpage.',
+      parameters: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description:
+              'The URL of the webpage to fetch and extract content from.',
+          },
+        },
+        required: ['url'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'memory.update', // Renamed from updateMemory
+      description:
+        'Appends a short summary or key piece of information to a special "memory" note in the popover. Use this to remember user preferences, facts about the user, or important context from the conversation for future reference within the current session or for the user to see in their popover note.',
+      parameters: {
+        type: 'object',
+        properties: {
+          summary: {
+            type: 'string',
+            description:
+              'The concise summary or piece of information to add to the memory. For example, "User is 30yo, he is building an extension".',
+          },
+        },
+        required: ['summary'],
+      },
+    },
+  },
+];

--- a/src/sidePanel/hooks/toolExecutors.ts
+++ b/src/sidePanel/hooks/toolExecutors.ts
@@ -1,0 +1,124 @@
+// src/sidePanel/hooks/toolExecutors.ts
+
+import { toast } from 'react-hot-toast';
+import { saveNoteInSystem } from 'src/background/noteStorage';
+import { scrapeUrlContent } from '../utils/scrapers';
+import { Config } from '../../types/config'; // Corrected path for Config
+import { saveNoteInSystem } from 'src/background/noteStorage';
+import { toast } from 'react-hot-toast';
+
+// Define UpdateConfig locally as its definition is simple and tied to how useConfig provides it
+export type UpdateConfig = (newConfig: Partial<Config>) => void;
+
+export interface SaveNoteArgs {
+  content: string;
+  title?: string;
+  tags?: string[] | string;
+}
+
+export interface UpdateMemoryArgs {
+  summary: string;
+}
+
+export interface FetcherArgs {
+  url: string;
+}
+
+export const executeSaveNote = async (
+  args: SaveNoteArgs
+): Promise<{ success: boolean; message: string }> => {
+  const { content, title } = args;
+  const llmTagsInput = args.tags;
+
+  if (!content || content.trim() === '') {
+    const msg = 'Note content cannot be empty for saving to system.';
+    toast.error(msg);
+    return { success: false, message: msg };
+  }
+
+  let parsedTags: string[] = [];
+  if (typeof llmTagsInput === 'string') {
+    parsedTags = llmTagsInput
+      .split(',')
+      .map((tag: string) => tag.trim())
+      .filter((tag) => tag.length > 0);
+  } else if (Array.isArray(llmTagsInput)) {
+    parsedTags = llmTagsInput
+      .map((tag: string) => String(tag).trim())
+      .filter((tag) => tag.length > 0);
+  }
+
+  try {
+    const timestamp = new Date().toLocaleString([], {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    const finalTitle = title?.trim() || `Note from AI - ${timestamp}`;
+    await saveNoteInSystem({
+      title: finalTitle,
+      content: content,
+      tags: parsedTags,
+    });
+    const msg = 'Note saved to system successfully!';
+    toast.success(msg);
+    return { success: true, message: msg };
+  } catch (error) {
+    console.error('Error saving note from LLM:', error);
+    const msg = 'Failed to save note to system.';
+    toast.error(msg);
+    return { success: false, message: msg };
+  }
+};
+
+export const executeUpdateMemory = (
+  args: UpdateMemoryArgs,
+  currentNoteContent: string | undefined, // Passed from useTools
+  updateConfig: UpdateConfig // Passed from useTools
+): { success: boolean; message: string } => {
+  const { summary } = args;
+
+  if (!summary || summary.trim() === '') {
+    const msg = 'Memory summary cannot be empty.';
+    toast.error(msg);
+    return { success: false, message: msg };
+  }
+
+  try {
+    const today = new Date().toLocaleDateString([], {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+    const memoryEntry = `${summary.trim()} (on ${today})`;
+
+    const separator = currentNoteContent && memoryEntry ? '\n\n' : '';
+    const newNoteContent = (currentNoteContent || '') + separator + memoryEntry;
+
+    updateConfig({ noteContent: newNoteContent });
+    const msg = 'Memory updated in popover note.';
+    toast.success(msg);
+    return { success: true, message: msg };
+  } catch (error) {
+    console.error('Error updating memory in popover note:', error);
+    const msg = 'Failed to update memory.';
+    toast.error(msg);
+    return { success: false, message: msg };
+  }
+};
+
+export const executeFetcher = async (args: FetcherArgs): Promise<string> => {
+  try {
+    const content = await scrapeUrlContent(args.url);
+    return content;
+  } catch (error: any) {
+    console.error(`Error executing fetcher for URL ${args.url}:`, error);
+    // Rethrow or return a specific error message string
+    if (typeof error === 'string' && error.startsWith('[Error scraping URL:')) {
+        return error;
+    }
+    return `Error fetching content for ${args.url}: ${error.message || 'Unknown error'}`;
+  }
+};

--- a/src/sidePanel/hooks/useTools.ts
+++ b/src/sidePanel/hooks/useTools.ts
@@ -1,23 +1,17 @@
+// src/sidePanel/hooks/useTools.ts
 import { useCallback } from 'react';
 import { useConfig } from '../ConfigContext';
-import { toast } from 'react-hot-toast';
-import { saveNoteInSystem } from 'src/background/noteStorage';
-import { scrapeUrlContent } from '../utils/scrapers';
+import { toolDefinitions, ToolDefinition } from './toolDefinitions';
+import {
+  executeSaveNote,
+  executeUpdateMemory,
+  executeFetcher,
+  SaveNoteArgs,
+  UpdateMemoryArgs,
+  FetcherArgs,
+} from './toolExecutors';
 
-interface SaveNoteArgs {
-  content: string;
-  title?: string;
-  tags?: string[] | string;
-}
-
-interface UpdateMemoryArgs {
-  summary: string;
-}
-
-interface FetcherArgs {
-  url: string;
-}
-
+// Interface for LLM tool calls (remains here as it's part of the execution layer)
 export interface LLMToolCall {
   id: string;
   type: 'function';
@@ -27,6 +21,7 @@ export interface LLMToolCall {
   };
 }
 
+// Interface for tool results (remains here)
 export interface ToolResult {
   tool_call_id: string;
   role: 'tool';
@@ -34,32 +29,12 @@ export interface ToolResult {
   content: string;
 }
 
-interface ToolParameterProperty {
-  type: string;
-  description: string;
-  enum?: string[];
-  items?: { type: string; };
-}
-
-export interface ToolDefinition {
-  type: 'function';
-  function: {
-    name: string;
-    description: string;
-    parameters: {
-      type: 'object';
-      properties: {
-        [key: string]: ToolParameterProperty;
-      };
-      required?: string[];
-    };
-  };
-}
-
+// Helper function to parse arguments (remains here)
 export const extractAndParseJsonArguments = (argsString: string): any => {
   try {
     return JSON.parse(argsString);
   } catch (e) {
+    // Ignore and try next method
   }
 
   const jsonFenceMatch = argsString.match(/```json\n([\s\S]*?)\n```/);
@@ -67,6 +42,7 @@ export const extractAndParseJsonArguments = (argsString: string): any => {
     try {
       return JSON.parse(jsonFenceMatch[1]);
     } catch (e) {
+      // Ignore and try next method
     }
   }
 
@@ -75,6 +51,7 @@ export const extractAndParseJsonArguments = (argsString: string): any => {
     try {
       return JSON.parse(genericFenceMatch[1]);
     } catch (e) {
+      // Ignore and try next method
     }
   }
 
@@ -95,171 +72,61 @@ export const extractAndParseJsonArguments = (argsString: string): any => {
 export const useTools = () => {
   const { config, updateConfig } = useConfig();
 
-  const saveNote = useCallback(async (args: SaveNoteArgs): Promise<{ success: boolean; message: string }> => {
-    const { content, title } = args;
-    const llmTagsInput = args.tags;
+  const executeToolCall = useCallback(
+    async (
+      llmToolCall: LLMToolCall | { name: string; arguments: string; id?: string }
+    ): Promise<{ toolCallId?: string; name: string; result: string }> => {
+      let toolName: string;
+      let rawArguments: string;
+      let toolCallId: string | undefined;
 
-    if (!content || content.trim() === '') {
-      const msg = 'Note content cannot be empty for saving to system.';
-      toast.error(msg);
-      return { success: false, message: msg };
-    }
-
-    let parsedTags: string[] = [];
-    if (typeof llmTagsInput === 'string') {
-      parsedTags = llmTagsInput.split(',').map((tag: string) => tag.trim()).filter(tag => tag.length > 0);
-    } else if (Array.isArray(llmTagsInput)) {
-      parsedTags = llmTagsInput.map((tag: string) => String(tag).trim()).filter(tag => tag.length > 0);
-    }
-
-    try {
-      const timestamp = new Date().toLocaleString([], { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
-      const finalTitle = title?.trim() || `Note from AI - ${timestamp}`;
-      await saveNoteInSystem({ title: finalTitle, content: content, tags: parsedTags });
-      const msg = 'Note saved to system successfully!';
-      toast.success(msg);
-      return { success: true, message: msg };
-    } catch (error) {
-      console.error('Error saving note from LLM:', error);
-      const msg = 'Failed to save note to system.';
-      toast.error(msg);
-      return { success: false, message: msg };
-    }
-  }, []);
-
-  const updateMemory = useCallback((args: UpdateMemoryArgs): { success: boolean; message: string } => {
-    const { summary } = args;
-
-    if (!summary || summary.trim() === '') {
-      const msg = 'Memory summary cannot be empty.';
-      toast.error(msg);
-      return { success: false, message: msg };
-    }
-
-    try {
-      const today = new Date().toLocaleDateString([], { year: 'numeric', month: 'short', day: 'numeric' });
-      const memoryEntry = `${summary.trim()} (on ${today})`;
-
-      const currentNote = config.noteContent || '';
-      const separator = currentNote && memoryEntry ? '\n\n' : '';
-      const newNoteContent = currentNote + separator + memoryEntry;
-
-      updateConfig({ noteContent: newNoteContent });
-      const msg = 'Memory updated in popover note.';
-      toast.success(msg);
-      return { success: true, message: msg };
-    } catch (error) {
-      console.error('Error updating memory in popover note:', error);
-      const msg = 'Failed to update memory.';
-      toast.error(msg);
-      return { success: false, message: msg };
-    }
-  }, [config.noteContent, updateConfig]);
-
-  const toolDefinitions: ToolDefinition[] = [
-    {
-      type: 'function',
-      function: {
-        name: 'saveNote',
-        description: 'Saves a new note to the user\'s persistent note system. Use this when the user wants to record information, decisions, or create a new structured note.',
-        parameters: {
-          type: 'object',
-          properties: {
-            content: {
-              type: 'string',
-              description: 'The main content of the note. This is mandatory.',
-            },
-            title: {
-              type: 'string',
-              description: 'An optional title for the note. If not provided, a default title will be generated.',
-            },
-            tags: {
-              type: 'array',
-              description: 'An optional list of tags (strings) to categorize the note.',
-              items: {
-                type: 'string'
-              }
-            },
-          },
-          required: ['content'],
-        },
-      },
-    },
-    {
-      type: 'function',
-      function: {
-        name: 'fetcher',
-        description: 'Fetches the main textual content of a given URL. Use this to get the content of a webpage.',
-        parameters: {
-          type: 'object',
-          properties: {
-            url: {
-              type: 'string',
-              description: 'The URL of the webpage to fetch and extract content from.',
-            },
-          },
-          required: ['url'],
-        },
-      },
-    },
-    {
-      type: 'function',
-      function: {
-        name: 'updateMemory',
-        description: 'Appends a short summary or key piece of information to a special "memory" note in the popover. Use this to remember user preferences, facts about the user, or important context from the conversation for future reference within the current session or for the user to see in their popover note.',
-        parameters: {
-          type: 'object',
-          properties: {
-            summary: {
-              type: 'string',
-              description: 'The concise summary or piece of information to add to the memory. For example, "User is 30yo, he is building an extension".',
-            },
-          },
-          required: ['summary'],
-        },
-      },
-    },
-  ];
-
-  const executeToolCall = async (
-    llmToolCall: LLMToolCall | { name: string; arguments: string; id?: string }
-  ): Promise<{ toolCallId?: string; name: string; result: string }> => {
-    let toolName: string;
-    let rawArguments: string;
-    let toolCallId: string | undefined;
-
-    if ('function' in llmToolCall) {
+      if ('function' in llmToolCall) {
         toolName = llmToolCall.function.name;
         rawArguments = llmToolCall.function.arguments;
-        toolCallId = (llmToolCall as any).id;
-    } else {
+        toolCallId = (llmToolCall as any).id; // Cast to any if id is not always present or type correctly
+      } else {
+        // Handling for direct call format (e.g. from UI interaction or test)
         toolName = llmToolCall.name;
         rawArguments = llmToolCall.arguments;
-        toolCallId = (llmToolCall as any).id;
-    }
-
-    try {
-      const args = extractAndParseJsonArguments(rawArguments);
-      if (toolName === 'saveNote') {
-        const { success, message } = await saveNote(args as SaveNoteArgs);
-        return { toolCallId, name: toolName, result: message };
-      } else if (toolName === 'updateMemory') {
-        const { success, message } = updateMemory(args as UpdateMemoryArgs);
-        return { toolCallId, name: toolName, result: message };
-      } else if (toolName === 'fetcher') {
-        const result = await scrapeUrlContent((args as FetcherArgs).url);
-        return { toolCallId, name: toolName, result };
-      } else {
-        return { toolCallId, name: toolName, result: `Error: Unknown tool '${toolName}'` };
+        toolCallId = llmToolCall.id;
       }
-    } catch (error: any) {
-      console.error(`Error executing tool ${toolName}:`, error);
-      if (toolName === 'fetcher' && typeof error === 'string' && error.startsWith('[Error scraping URL:')) {
-        return { toolCallId, name: toolName, result: error };
-      }
-      return { toolCallId, name: toolName, result: `Error parsing arguments or executing tool ${toolName}: ${error.message}` };
-    }
-  };
 
-  return { saveNote, updateMemory, toolDefinitions, executeToolCall };
+      try {
+        const args = extractAndParseJsonArguments(rawArguments);
+
+        if (toolName === 'note.save') { // Updated name
+          const { message } = await executeSaveNote(args as SaveNoteArgs);
+          return { toolCallId, name: toolName, result: message };
+        } else if (toolName === 'memory.update') { // Updated name
+          const { message } = executeUpdateMemory(
+            args as UpdateMemoryArgs,
+            config.noteContent,
+            updateConfig
+          );
+          return { toolCallId, name: toolName, result: message };
+        } else if (toolName === 'fetcher') {
+          const result = await executeFetcher(args as FetcherArgs);
+          return { toolCallId, name: toolName, result };
+        } else {
+          console.error(`Error: Unknown tool '${toolName}'`);
+          return { toolCallId, name: toolName, result: `Error: Unknown tool '${toolName}'` };
+        }
+      } catch (error: any) {
+        console.error(`Error executing tool ${toolName}:`, error);
+        // Specific error handling for fetcher can be kept if desired, or generalized
+        if (toolName === 'fetcher' && typeof error === 'string' && error.startsWith('[Error scraping URL:')) {
+            return { toolCallId, name: toolName, result: error };
+        }
+        return {
+          toolCallId,
+          name: toolName,
+          result: `Error parsing arguments or executing tool ${toolName}: ${error.message || 'Unknown error'}`,
+        };
+      }
+    },
+    [config.noteContent, updateConfig] // Dependencies for useCallback
+  );
+
+  // Expose toolDefinitions directly from the imported module
+  return { toolDefinitions, executeToolCall };
 };


### PR DESCRIPTION
- Moved tool definitions to toolDefinitions.ts
- Moved tool executor logic to toolExecutors.ts
- Renamed tools: saveNote -> note.save, updateMemory -> memory.update
- useTools.ts now acts as an execution layer, mapping calls to executors.