### PR TITLE
Feat: Enhance LLM prompting for note context

### DIFF
--- a/src/sidePanel/hooks/useSendMessage.ts
+++ b/src/sidePanel/hooks/useSendMessage.ts
@@ -501,7 +501,20 @@ const useSendMessage = (
     if (persona) systemPromptParts.push(persona);
     if (userContextStatement) systemPromptParts.push(userContextStatement);
     if (noteContextString) systemPromptParts.push(noteContextString);
-    if (notesContextContent) systemPromptParts.push(notesContextContent);
+    if (notesContextContent) {
+      let noteIntro = "The user has provided the following note(s) for context. Please consider them when formulating your response:";
+      if (selectedNotesForContext && selectedNotesForContext.length > 0) {
+          const noteTitles = selectedNotesForContext.map(n => `"${n.title}"`).join(', ');
+          if (selectedNotesForContext.length === 1) {
+              noteIntro = `The user has provided a note titled ${noteTitles} for context. Please consider it when formulating your response:`;
+          } else {
+              noteIntro = `The user has provided notes titled ${noteTitles} for context. Please consider them when formulating your response:`;
+          }
+      }
+      systemPromptParts.push(noteIntro + "\n\n" + notesContextContent);
+
+      systemPromptParts.push("If the user's query is general and could relate to the content of these provided notes, please acknowledge their relevance or use information from them in your response.");
+    }
     if (scrapedContent) systemPromptParts.push(`Use the following scraped content from URLs in the user's message:\n${scrapedContent}`);
     if (pageContextString) systemPromptParts.push(pageContextString);
     if (webContextString) systemPromptParts.push(webContextString);


### PR DESCRIPTION
Modified `useSendMessage.ts` to improve LLM awareness and usage of user-provided notes.

Changes:
- Added a dynamic introductory phrase to the system prompt when notes are present, explicitly stating that the following content is from user notes and mentioning their titles.
- Included an additional instruction guiding the LLM to acknowledge or use information from these notes if the user's query is general and could relate to them.

This aims to address scenarios where the LLM might not effectively utilize note context for vague user queries by providing clearer signals and instructions.