### PR TITLE
fix: Correct casing for DuckDuckGo search mode

### DIFF
--- a/src/sidePanel/WebSearch.tsx
+++ b/src/sidePanel/WebSearch.tsx
@@ -37,7 +37,7 @@ const WebSearchModeSelector = ({ webMode, updateConfig }: WebSearchModeSelectorP
           htmlFor={`webMode-${mode}`}
           className="text-[var(--text)] text-base font-medium cursor-pointer"
         >
-          {mode === 'GoogleCustomSearch' ? 'Google Custom API' : mode}
+          {mode === 'GoogleCustomSearch' ? 'Google Custom API' : mode === 'Duckduckgo' ? 'DuckDuckGo' : mode}
         </Label>
       </div>
     ))}

--- a/src/sidePanel/hooks/toolExecutors.ts
+++ b/src/sidePanel/hooks/toolExecutors.ts
@@ -323,7 +323,7 @@ export const executeWebSearch = async (
     return 'Error: "queries" must be a non-empty array of objects, each with a non-empty "query" string.';
   }
 
-  const fallbackEngines: ('Google' | 'DuckDuckGo' | 'Brave')[] = ['Google', 'DuckDuckGo', 'Brave'];
+  const fallbackEngines: ('Google' | 'Duckduckgo' | 'Brave')[] = ['Google', 'Duckduckgo', 'Brave'];
 
   const searchPromises = queries.map(async ({ query, engine }) => {
     // This inner logic is mostly correct, but we will let it throw on failure.


### PR DESCRIPTION
Web searches for DuckDuckGo were failing because of a casing mismatch. There was an internal inconsistency between 'Duckduckgo' and the expected 'DuckDuckGo'.

This change corrects the casing to resolve the issue and ensures 'DuckDuckGo' is used consistently.