### PR TITLE
feat(ux): Make Send button tooltip dynamic

### DIFF
--- a/src/sidePanel/Input.tsx
+++ b/src/sidePanel/Input.tsx
@@ -595,7 +595,15 @@ export const Input: FC<InputProps> = ({
               )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent className="bg-secondary/50 text-foreground" side="top"><p>{isLoading || isRetrieving ? "Stop" : "Send"}</p></TooltipContent>
+          <TooltipContent className="bg-secondary/50 text-foreground" side="top">
+            <p>
+              {isLoading || isRetrieving
+                ? "Stop"
+                : !message.trim()
+                  ? "Cannot send an empty message"
+                  : "Send"}
+            </p>
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </div>


### PR DESCRIPTION
Provides clearer user feedback by changing the tooltip text based on the button's state.

- When the input is empty, the tooltip now reads "Cannot send an empty message".
- When loading or retrieving, it reads "Stop".
- Otherwise, it reads "Send".

This small change improves usability by explaining why the send button is disabled, reducing potential user confusion.