### PR TITLE
Fix markdown/HTML stripping in gentleProcessText for search indexing

### DIFF
--- a/src/background/textProcessing.ts
+++ b/src/background/textProcessing.ts
@@ -159,8 +159,28 @@ export function gentleProcessText(text: string): string {
     // Replace image markdown (with or without title) with alt text.
     cleanedText = cleanedText.replace(/!\[(.*?)\]\([^)"']+(?:["'][^"']*["'])?\)/g, '$1');
 
+    // Replace link markdown with its visible text.
+    cleanedText = cleanedText.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+
     // Remove HTML comments.
     cleanedText = cleanedText.replace(/<!--[\s\S]*?-->/g, '');
+
+    // Strip remaining HTML tags, keeping their text content.
+    cleanedText = cleanedText.replace(/<\/?[a-zA-Z][^>]*>/g, ' ');
+
+    // Remove markdown heading markers (e.g. "### Title" → "Title").
+    cleanedText = cleanedText.replace(/^#{1,6}\s+/gm, '');
+
+    // Remove bold/italic emphasis markers, keeping the wrapped text.
+    // (Single "*"/"_" markers are intentionally left alone since they also
+    // occur inside snake_case identifiers and multiplication like "a * b".)
+    cleanedText = cleanedText
+        .replace(/(\*\*\*|___)(.+?)\1/g, '$2')
+        .replace(/(\*\*|__)(.+?)\1/g, '$2');
+
+    // Remove inline code backticks, keeping the code text. Scoped to a
+    // single line so it doesn't pair backticks across a fenced code block.
+    cleanedText = cleanedText.replace(/`([^`\n]+)`/g, '$1');
 
     // Decode common HTML entities.
     cleanedText = cleanedText


### PR DESCRIPTION
I've been using Cognito for notes and got curious how the search indexing actually works under the hood, so I started reading through `src/background/textProcessing.ts`. `gentleProcessText` (imported elsewhere under its older name `cleanMarkdownForSemantics`) doesn't actually strip much markdown or HTML anymore. It only handles image syntax and HTML comments — links, headings, bold/italic markers, inline code, and plain `<tags>` all pass straight through.

That matters because this function's output (`cleanContent`) is exactly what feeds the BM25 index for both notes (`noteStorage.ts`) and chat messages (`chatHistoryStorage.ts`). It's only ever used to build `bm25Content` — the raw content that actually gets saved/displayed is untouched, so this is purely about search quality. A note like:

```
## Project ideas
Check the [roadmap](https://example.com) for **details**.
```

currently gets indexed with literal `##`, `[roadmap](https://example.com)`, and `**` characters mixed into the search tokens, diluting the actual keywords.

Worth noting: the checked-in tests in `src/background/__tests__/textProcessing.test.ts` (the `cleanMarkdownForSemantics` describe block) already assert this exact stripping behavior — HTML tag removal, markdown link/heading/bold handling — and 4 of them were failing against the current implementation before this change. Looks like the markdown-stripping logic got dropped in the `d72fc40` rewrite (renaming it from `cleanMarkdownForSemantics` to `gentleProcessText` while switching the BM25 tokenizer to `Intl.Segmenter`), and the tests were never updated to match.

**What I changed:** added handling in `gentleProcessText` for markdown links, headings, bold/italic emphasis, inline code, and generic HTML tags, on top of what was already there (images, comments, entities, quotes, whitespace). I deliberately left single `*`/`_` markers alone since those also show up in snake_case identifiers and things like `a * b`, and scoped the inline-code regex to a single line so it can't accidentally pair backticks across a fenced code block.

**Testing:**
- `npx vitest run`: went from 6 failed / 102 passed on `main` to 3 failed / 105 passed. The remaining 3 failures are all in the unrelated `lexicalProcessText` Japanese/Korean tests (`Intl.Segmenter` tokenization behavior, pre-existing, untouched by this change).
- `npx tsc --noEmit`: clean.
- `npx webpack --config config/webpack.config.js` (one-off, not watch mode): compiles fine.
- `npx eslint .`: fails at baseline on `main` too, on an unrelated ESLint config schema error (`comma-dangle`) — not something I touched.

Small, self-contained change — one function, no changes to what's actually stored or rendered.
